### PR TITLE
Add Keyvault support for db credentials

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,25 @@
 import os
 
+from azure.keyvault import KeyVaultClient
+from msrestazure.azure_active_directory import MSIAuthentication
+
+def _get_database_uri():
+
+    if "APPSETTING_WEBSITE_SITE_NAME" in os.environ:
+        credentials = MSIAuthentication(resource='https://vault.azure.net')
+        key_vault_client = KeyVaultClient(credentials)
+
+        key_vault_uri = os.environ.get("KEY_VAULT_URI")
+
+        return key_vault_client.get_secret(
+            key_vault_uri,
+            "database-url",
+            ""
+        )
+    else:
+        return TestingConfig.SQLALCHEMY_DATABASE_URI
+
+
 
 class BaseConfig(object):
     DEBUG = False
@@ -14,7 +34,7 @@ class TestingConfig(BaseConfig):
 
 
 class ProductionConfig(BaseConfig):
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', TestingConfig.SQLALCHEMY_DATABASE_URI)
+    SQLALCHEMY_DATABASE_URI = _get_database_uri(),
     APPINSIGHTS_INSTRUMENTATIONKEY = os.environ.get('APPINSIGHTS_INSTRUMENTATIONKEY', TestingConfig.APPINSIGHTS_INSTRUMENTATIONKEY)
     SECRET_KEY = os.environ.get('SECRET_KEY', TestingConfig.SECRET_KEY)
     

--- a/app/config.py
+++ b/app/config.py
@@ -3,22 +3,24 @@ import os
 from azure.keyvault import KeyVaultClient
 from msrestazure.azure_active_directory import MSIAuthentication
 
+def _is_app_service():
+    return 'APPSETTING_WEBSITE_SITE_NAME' in os.environ
+
 def _get_database_uri():
 
-    if "APPSETTING_WEBSITE_SITE_NAME" in os.environ:
-        credentials = MSIAuthentication(resource='https://vault.azure.net')
+    if _is_app_service():
+        credentials = MSIAuthentication()
         key_vault_client = KeyVaultClient(credentials)
 
         key_vault_uri = os.environ.get("KEY_VAULT_URI")
 
         return key_vault_client.get_secret(
-            key_vault_uri,
-            "database-url",
-            ""
+            vault_base_url=key_vault_uri,
+            secret_name="database-url",
+            secret_version="" # empty string -> latest secret version
         )
     else:
         return TestingConfig.SQLALCHEMY_DATABASE_URI
-
 
 
 class BaseConfig(object):

--- a/app/config.py
+++ b/app/config.py
@@ -12,12 +12,12 @@ def _get_database_uri():
         credentials = MSIAuthentication()
         key_vault_client = KeyVaultClient(credentials)
 
-        key_vault_uri = os.environ.get("KEY_VAULT_URI")
+        key_vault_uri = os.environ.get("KEY_VAULT_URI", "PUT YOUR KV BASE URL HERE")
 
         return key_vault_client.get_secret(
             vault_base_url=key_vault_uri,
             secret_name="database-url",
-            secret_version="" # empty string -> latest secret version
+            secret_version="" # empty string -> latest version
         )
     else:
         return TestingConfig.SQLALCHEMY_DATABASE_URI

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask_script==2.0.6
 psycopg2==2.7.5
 flask_bcrypt==0.7.1
 applicationinsights==0.11.8
+azure-mgmt-keyvault==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ flask_script==2.0.6
 psycopg2==2.7.5
 flask_bcrypt==0.7.1
 applicationinsights==0.11.8
-azure-mgmt-keyvault==1.1.0
+azure-keyvault==1.1.0


### PR DESCRIPTION
This PR cribs heavily from 

https://azure.microsoft.com/en-us/resources/samples/key-vault-python-manage/

Separately:

* `team-standup` KeyVault has been added in the Azure Portal with `database-url` secret
* `KEY_VAULT_URI` env var was added to application service settings 
* System assigned Managed Identity was enabled for the app service

It's unclear to me if there are other necessary steps I have missed, so comments are welcome. 